### PR TITLE
Sample-accurate seeking and memory usage optimizations

### DIFF
--- a/DecoderDemo.java
+++ b/DecoderDemo.java
@@ -127,7 +127,7 @@ class DecoderDemo
 		
 		while (true)
 		{
-			bytes_unpacked = AlacUtils.AlacUnpackSamples(ac, pDestBuffer).bytesUnpacked;
+			bytes_unpacked = AlacUtils.AlacUnpackSamples(ac, pDestBuffer);
 
 			total_unpacked_bytes += bytes_unpacked;
 

--- a/DecoderDemo.java
+++ b/DecoderDemo.java
@@ -127,9 +127,7 @@ class DecoderDemo
 		
 		while (true)
 		{
-			bytes_unpacked = 0;
-
-			bytes_unpacked = AlacUtils.AlacUnpackSamples(ac, pDestBuffer);
+			bytes_unpacked = AlacUtils.AlacUnpackSamples(ac, pDestBuffer).bytesUnpacked;
 
 			total_unpacked_bytes += bytes_unpacked;
 

--- a/com/beatofthedrum/alacdecoder/AlacContext.java
+++ b/com/beatofthedrum/alacdecoder/AlacContext.java
@@ -15,7 +15,7 @@ public class AlacContext
 {
 	DemuxResT demux_res = new DemuxResT();
 	AlacFile alac = new AlacFile();
-	java.io.DataInputStream input_stream;
+	AlacInputStream input_stream;
 	int current_sample_block = 0;
 	public boolean error;
 	public String error_message = "";

--- a/com/beatofthedrum/alacdecoder/AlacContext.java
+++ b/com/beatofthedrum/alacdecoder/AlacContext.java
@@ -20,4 +20,5 @@ public class AlacContext
     int offset;
 	public boolean error;
 	public String error_message = "";
+    byte[] read_buffer = new byte[1024 *80]; // sample big enough to hold any input for a single alac frame
 }

--- a/com/beatofthedrum/alacdecoder/AlacContext.java
+++ b/com/beatofthedrum/alacdecoder/AlacContext.java
@@ -17,6 +17,7 @@ public class AlacContext
 	AlacFile alac = new AlacFile();
 	AlacInputStream input_stream;
 	int current_sample_block = 0;
+    int offset;
 	public boolean error;
 	public String error_message = "";
 }

--- a/com/beatofthedrum/alacdecoder/AlacFile.java
+++ b/com/beatofthedrum/alacdecoder/AlacFile.java
@@ -13,7 +13,7 @@ package com.beatofthedrum.alacdecoder;
 class AlacFile
 {
 
-	int input_buffer[] = new int[81920];
+	byte input_buffer[];
 	int ibIdx = 0;
 	int input_buffer_bitaccumulator = 0; /* used so we can do arbitary
 						bit reads */
@@ -22,16 +22,19 @@ class AlacFile
 	int numchannels = 0;
 	int bytespersample = 0;
 
+    LeadingZeros lz = new LeadingZeros();
 
-	/* buffers */
-	int predicterror_buffer_a[] = new int[65536];
-	int predicterror_buffer_b[] = new int[65536];
 
-	int outputsamples_buffer_a[] = new int[65536];
-	int outputsamples_buffer_b[] = new int[65536];
+    private int buffer_size = 16384;
+    /* buffers */
+	int predicterror_buffer_a[] = new int[buffer_size];
+	int predicterror_buffer_b[] = new int[buffer_size];
 
-	int uncompressed_bytes_buffer_a[] = new int[65536];
-	int uncompressed_bytes_buffer_b[] = new int[65536];
+	int outputsamples_buffer_a[] = new int[buffer_size];
+	int outputsamples_buffer_b[] = new int[buffer_size];
+
+	int uncompressed_bytes_buffer_a[] = new int[buffer_size];
+	int uncompressed_bytes_buffer_b[] = new int[buffer_size];
 
 
 
@@ -52,5 +55,8 @@ class AlacFile
 	/* bit rate (avarge)?? */
 	int setinfo_8a_rate = 0; // 0x0000ac44
 	/* end setinfo stuff */
- 
+
+    public int[] predictor_coef_table = new int[1024];
+    public int[] predictor_coef_table_a = new int[1024];
+    public int[] predictor_coef_table_b = new int[1024];
 }

--- a/com/beatofthedrum/alacdecoder/AlacInputStream.java
+++ b/com/beatofthedrum/alacdecoder/AlacInputStream.java
@@ -1,0 +1,32 @@
+package com.beatofthedrum.alacdecoder;
+
+import java.io.DataInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Author: Denis Tulskiy
+ * Date: 4/7/11
+ */
+public class AlacInputStream extends DataInputStream {
+    /**
+     * Creates a DataInputStream that uses the specified
+     * underlying InputStream.
+     *
+     * @param in the specified input stream
+     */
+    public AlacInputStream(InputStream in) {
+        super(in);
+    }
+
+    public void seek(long pos) {
+        if (in instanceof FileInputStream) {
+            try {
+                ((FileInputStream) in).getChannel().position(pos);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/com/beatofthedrum/alacdecoder/ChunkInfo.java
+++ b/com/beatofthedrum/alacdecoder/ChunkInfo.java
@@ -1,0 +1,11 @@
+package com.beatofthedrum.alacdecoder;
+
+/**
+ * Author: Denis Tulskiy
+ * Date: 4/9/11
+ */
+public class ChunkInfo {
+    int first_chunk;
+    int samples_per_chunk;
+    int sample_desc_index;
+}

--- a/com/beatofthedrum/alacdecoder/DecodeResult.java
+++ b/com/beatofthedrum/alacdecoder/DecodeResult.java
@@ -1,0 +1,10 @@
+package com.beatofthedrum.alacdecoder;
+
+/**
+ * Author: Denis Tulskiy
+ * Date: 4/9/11
+ */
+public class DecodeResult {
+    public int bytesUnpacked;
+    public int offset;
+}

--- a/com/beatofthedrum/alacdecoder/DemuxResT.java
+++ b/com/beatofthedrum/alacdecoder/DemuxResT.java
@@ -23,8 +23,7 @@ class DemuxResT
 	public SampleInfo[] time_to_sample = new SampleInfo[16];
 	public int num_time_to_samples;
 
-	public int[] sample_byte_size = new int[65536];
-	public int num_sample_byte_sizes;
+	public int[] sample_byte_size;
 
 	public int codecdata_len;
 

--- a/com/beatofthedrum/alacdecoder/DemuxResT.java
+++ b/com/beatofthedrum/alacdecoder/DemuxResT.java
@@ -30,6 +30,9 @@ class DemuxResT
 
 	public int[] codecdata = new int[1024];
 
+    public int[] stco;
+    public ChunkInfo[] stsc;
+
 	public int mdat_len;
 	
 	public DemuxResT()

--- a/com/beatofthedrum/alacdecoder/DemuxUtils.java
+++ b/com/beatofthedrum/alacdecoder/DemuxUtils.java
@@ -436,7 +436,7 @@ class DemuxUtils
 			
 			uniform_num = (StreamUtils.stream_read_uint32(qtmovie.qtstream));
 			
-			qtmovie.res.num_sample_byte_sizes = uniform_num;
+			qtmovie.res.sample_byte_size = new int[uniform_num];
 			
 			for (i = 0; i < uniform_num; i++)
 			{
@@ -459,7 +459,7 @@ class DemuxUtils
 
 		size_remaining -= 4;
 
-		qtmovie.res.num_sample_byte_sizes = numentries;
+		qtmovie.res.sample_byte_size = new int[numentries];
 
 		for (i = 0; i < numentries; i++)
 		{

--- a/com/beatofthedrum/alacdecoder/MyStream.java
+++ b/com/beatofthedrum/alacdecoder/MyStream.java
@@ -15,4 +15,5 @@ class MyStream
 {
 	public java.io.DataInputStream stream;
 	public int currentPos = 0;
+    public byte[] read_buf = new byte[8];
 }

--- a/com/beatofthedrum/alacdecoder/QTMovieT.java
+++ b/com/beatofthedrum/alacdecoder/QTMovieT.java
@@ -19,7 +19,6 @@ class QTMovieT
 
 	public QTMovieT()
 	{
-		res = new DemuxResT();
 		saved_mdat_pos = 0;
 		qtstream = new MyStream();
 	}

--- a/com/beatofthedrum/alacdecoder/StreamUtils.java
+++ b/com/beatofthedrum/alacdecoder/StreamUtils.java
@@ -13,33 +13,35 @@ package com.beatofthedrum.alacdecoder;
 
 class StreamUtils
 {
-	public static void stream_read(MyStream mystream, int size, int[] buf, int startPos)
+    public static void stream_read(MyStream mystream, int size, int[] buf, int startPos) {
+        byte[] byteBuf = new byte[size];
+        int bytes_read = stream_read(mystream, size, byteBuf, 0);
+        for(int i=0; i < bytes_read; i++) {
+			buf[startPos + i] = byteBuf[i];
+		}
+    }
+
+	public static int stream_read(MyStream mystream, int size, byte[] buf, int startPos)
 	{
 		int bytes_read = 0;
-		byte[] bytebuf = new byte[size];
-		
+
 		try
 		{
-			bytes_read = mystream.stream.read(bytebuf, 0, size);
+			bytes_read = mystream.stream.read(buf, startPos, size);
 		}
 		catch (Exception err)
 		{
 			System.err.println("stream_read: exception thrown: " + err);
 		}
 		mystream.currentPos = mystream.currentPos + bytes_read;
-		
-		for(int i=0; i < bytes_read; i++)
-		{
-			buf[startPos + i] = bytebuf[i];
-		}
-
+        return bytes_read;
 	}
 
 	public static int stream_read_uint32(MyStream mystream)
 	{
 		int v = 0;
 		int tmp = 0;
-		byte[] bytebuf = new byte[4];
+		byte[] bytebuf = mystream.read_buf;
 		int bytes_read = 0;
 
 		try
@@ -86,7 +88,7 @@ class StreamUtils
 	{
 		int v = 0;
 		int tmp = 0;
-		byte[] bytebuf = new byte[2];
+		byte[] bytebuf = mystream.read_buf;
 		int bytes_read = 0;
 
 		try
@@ -110,7 +112,7 @@ class StreamUtils
 	{
 		int v = 0;
 		int bytes_read = 0;
-		byte[] bytebuf = new byte[1];
+		byte[] bytebuf = mystream.read_buf;
 		
 		try
 		{
@@ -127,62 +129,24 @@ class StreamUtils
 
 	public static void stream_skip(MyStream mystream, int skip)
 	{
-		byte[] bytebuf = new byte[8192];
-		int toskip = skip;
-		int toget = 0;
-		int bytes_read = 0;
-		int method_to_skip = 2;		// method used to skip data
+        int toskip = skip;
+        int bytes_read = 0;
 
-		if(toskip < 0)
+        if(toskip < 0)
 		{
 			System.err.println("stream_skip: request to seek backwards in stream - not supported, sorry");
 			return;
 		}
 
-		/*
-		** 3 ways to skip within file
-		** 1) read in chunks (ignoring data) till skip done
-		** 2) use skipBytes to skip required amount
-		** 3) with a stream that supports seeking, seek to new location
-		*/
-	
-		if(method_to_skip == 1)
-		{		
-			while(toskip > 0)
-			{
-				if(toskip > 8192)
-				{
-					toget = 8192;
-					toskip = toskip - 8192;
-				}
-				else
-				{
-					toget = toskip;
-					toskip = 0;
-				}
-
-				try
-				{
-					bytes_read = mystream.stream.read(bytebuf, 0, toget);
-					mystream.currentPos = mystream.currentPos + bytes_read;
-				}
-				catch (Exception e)
-				{
-				}
-			}
-		}
-		else if (method_to_skip == 2)
-		{
-			try
-			{
-				bytes_read = mystream.stream.skipBytes(toskip);
-				mystream.currentPos = mystream.currentPos + bytes_read;
-			}
-			catch (java.io.IOException ioe)
-			{
-			}
-		}
-	}
+        try
+        {
+            bytes_read = mystream.stream.skipBytes(toskip);
+            mystream.currentPos = mystream.currentPos + bytes_read;
+        }
+        catch (java.io.IOException ioe)
+        {
+        }
+    }
 
 	public static int stream_eof(MyStream mystream)
 	{


### PR DESCRIPTION
Hi, here are three commits that address sample-accurate seeking and one commit to optimize memory usage. 
The one about memory is a bit dirty because some of the changes are because of changed line endings, sorry. I had to include it because the decoder was generating massive amounts of short-lived objects and it was a bit too much load on the garbage collector. It might not be an issue for a standalone decoder. I hope it doesn't break anything.
